### PR TITLE
Fix bug in `time` output

### DIFF
--- a/lib/null_statsd/statsd.rb
+++ b/lib/null_statsd/statsd.rb
@@ -51,8 +51,8 @@ module NullStatsd
     end
 
     def time(stat, _opts = {})
-      time_in_ms, result = benchmark { yield }
-      logger.debug "#{identifier_string} Recording timing info in #{stat} -> #{time_in_ms} ms"
+      time_in_sec, result = benchmark { yield }
+      logger.debug "#{identifier_string} Recording timing info in #{stat} -> #{time_in_sec} sec"
       result
     end
 

--- a/lib/null_statsd/version.rb
+++ b/lib/null_statsd/version.rb
@@ -1,3 +1,3 @@
 module NullStatsd
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
The timing is acutally measured in seconds, not milliseconds
